### PR TITLE
Fix the flaky test in TestPrometheusRecordSink.java

### DIFF
--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -104,8 +104,8 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n") || content.contains("field1{field3=\"World!\",} 6.0\nfield1{field3=\"Hello\",} 15.0\n"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n") || content.contains("field2{field3=\"World!\",} 0.12345678901234568\nfield2{field3=\"Hello\",} 12.34567\n"));
 
         try {
             sink.onStopped();


### PR DESCRIPTION
The test TestPrometheusRecordSink.testSendData compare the string representation of the EntityUtils(EntityUtils.toString()) with a hardcoded string.
However, the test will sometimes fail since the function EntityUtils.toString() can not guarantee the order of the returned string.
The cause is that the HttpEntity Object might has a non-deterministic specification that do not guarantee that the order of elements in it.

To fix this test, I updated the test case, which will check only the content and not the order of the output strings.